### PR TITLE
Faster stats generator

### DIFF
--- a/generator/meetup.go
+++ b/generator/meetup.go
@@ -3,9 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"math"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -177,50 +179,60 @@ func aggregateStats(cfg *Config) (*StatsFile, error) {
 	s := &StatsFile{
 		PerMeetup: map[string]MeetupStats{},
 	}
-	for _, mg := range cfg.MeetupGroups {
-		mgStat := MeetupStats{}
-		mgStat.Members = mg.members
-		totalAttendees := uint64(0)
-		// allAttendees maps an user ID to the amount of RSVPs for that user
-		allAttendees := map[uint64]uint64{}
-		priorMeetups := uint64(0)
-		for _, m := range mg.Meetups {
-			if m.Date.UTC().After(time.Now().UTC()) {
-				continue
-			}
-			priorMeetups++
-			totalAttendees += m.Attendees
 
-			attendance, err := GetAttendanceList(mg.MeetupID, m.ID)
-			if err != nil {
-				return nil, err
-			}
-			for _, attendee := range attendance {
-				if attendee.RSVP.Response != "yes" {
+	var wg sync.WaitGroup
+	wg.Add(len(cfg.MeetupGroups))
+
+	for _, mg := range cfg.MeetupGroups {
+		go func(mg MeetupGroup) {
+			defer wg.Done()
+
+			mgStat := MeetupStats{}
+			mgStat.Members = mg.members
+			totalAttendees := uint64(0)
+			// allAttendees maps an user ID to the amount of RSVPs for that user
+			allAttendees := map[uint64]uint64{}
+			priorMeetups := uint64(0)
+			for _, m := range mg.Meetups {
+				if m.Date.UTC().After(time.Now().UTC()) {
 					continue
 				}
-				rsvps, ok := allAttendees[attendee.Member.ID]
-				if ok {
-					allAttendees[attendee.Member.ID] = rsvps + attendee.RSVP.Guests
-				} else {
-					allAttendees[attendee.Member.ID] = 1 + attendee.RSVP.Guests
+				priorMeetups++
+				totalAttendees += m.Attendees
+
+				attendance, err := GetAttendanceList(mg.MeetupID, m.ID)
+				if err != nil {
+					log.Fatalf("error: %v", err)
+					return
+				}
+				for _, attendee := range attendance {
+					if attendee.RSVP.Response != "yes" {
+						continue
+					}
+					rsvps, ok := allAttendees[attendee.Member.ID]
+					if ok {
+						allAttendees[attendee.Member.ID] = rsvps + attendee.RSVP.Guests
+					} else {
+						allAttendees[attendee.Member.ID] = 1 + attendee.RSVP.Guests
+					}
 				}
 			}
-		}
-		mgStat.Attendees = totalAttendees
-		mgStat.Meetups = priorMeetups
-		mgStat.AverageAttendees = uint64(math.Floor(float64(mgStat.Attendees / mgStat.Meetups)))
-		for _, num := range allAttendees {
-			mgStat.UniqueAttendees += num
-		}
+			mgStat.Attendees = totalAttendees
+			mgStat.Meetups = priorMeetups
+			mgStat.AverageAttendees = uint64(math.Floor(float64(mgStat.Attendees / mgStat.Meetups)))
+			for _, num := range allAttendees {
+				mgStat.UniqueAttendees += num
+			}
 
-		s.PerMeetup[mg.CityLowercase()] = mgStat
+			s.PerMeetup[mg.CityLowercase()] = mgStat
 
-		s.AllMeetups.Meetups += mgStat.Meetups
-		s.AllMeetups.Members += mgStat.Members
-		s.AllMeetups.Attendees += mgStat.Attendees
-		s.AllMeetups.UniqueAttendees += mgStat.UniqueAttendees
+			s.AllMeetups.Meetups += mgStat.Meetups
+			s.AllMeetups.Members += mgStat.Members
+			s.AllMeetups.Attendees += mgStat.Attendees
+			s.AllMeetups.UniqueAttendees += mgStat.UniqueAttendees
+		}(mg)
 	}
+	wg.Wait()
 	s.AllMeetups.AverageAttendees = uint64(math.Floor(float64(s.AllMeetups.Attendees / s.AllMeetups.Meetups)))
 	return s, nil
 }

--- a/stats.json
+++ b/stats.json
@@ -1,7 +1,7 @@
 {
   "allMeetups": {
     "meetups": 45,
-    "members": 3003,
+    "members": 3005,
     "attendees": 2783,
     "averageAttendees": 61,
     "uniqueAttendees": 1507
@@ -9,28 +9,28 @@
   "perMeetup": {
     "aarhus": {
       "meetups": 20,
-      "members": 806,
+      "members": 807,
       "attendees": 1130,
       "averageAttendees": 56,
       "uniqueAttendees": 457
     },
     "copenhagen": {
       "meetups": 10,
-      "members": 669,
+      "members": 670,
       "attendees": 483,
       "averageAttendees": 48,
       "uniqueAttendees": 316
     },
     "helsinki": {
       "meetups": 9,
-      "members": 742,
+      "members": 741,
       "attendees": 690,
       "averageAttendees": 76,
       "uniqueAttendees": 365
     },
     "stockholm": {
       "meetups": 3,
-      "members": 635,
+      "members": 636,
       "attendees": 332,
       "averageAttendees": 110,
       "uniqueAttendees": 273


### PR DESCRIPTION
@luxas 

This pr makes generating `stats.json` faster. This was achieved by using goroutines for each meetup group. I did some tests before and after this change, and this resulted in 50% reduction of time it takes to generate `stats.json` on my computer.