### PR TITLE
Manually add new blank meetups

### DIFF
--- a/aalborg/README.md
+++ b/aalborg/README.md
@@ -16,6 +16,23 @@
 - Simon Bengtsson, Systems Engineer, [Spar Nord Bank](https://www.sparnord.dk/)
 - Camilla Larsen, Systems Engineer, [Spar Nord Bank](https://www.sparnord.dk/)
 
+### #4 Istio in production, Prometheus 101 and Gitops
+
+- Date: 11 December, 2019 at 16:45 - 20:00
+- Meetup link: https://www.meetup.com/Cloud-Native-Aalborg/events/265893647
+
+#### Agenda
+
+
+### #3 Observability II
+
+- Date: 6 November, 2019 at 16:30 - 19:30
+- Meetup link: https://www.meetup.com/Cloud-Native-Aalborg/events/263745012
+- Attendees (according to meetup.com): 33
+
+#### Agenda
+
+
 ### #2 - Kubernetes Intro, Automated install and Observability
 
 - Date: 10 October, 2019 at 16:45 - 20:00

--- a/aalborg/meetup.yaml
+++ b/aalborg/meetup.yaml
@@ -94,6 +94,14 @@ meetups:
     sponsors:
     - company: sparnordbank
       role: Venue
+  "20191106":
+    presentations: null
+    recording: ""
+    sponsors: null
+  "20191211":
+    presentations: null
+    recording: ""
+    sponsors: null
 organizers:
 - allanhojgaardjensen
 - arnemejlholm

--- a/aarhus/README.md
+++ b/aarhus/README.md
@@ -15,6 +15,22 @@
 - Henrik Høegh [@hoeghh](https://github.com/hoeghh), [Praqma](https://www.praqma.com/)
 - Daniel Fly [@sazo](https://github.com/sazo), [Zitcom](https://www.zitcom.dk/)
 
+### Happy Holidays Edition with GitOps and Exploiting the winds of change
+
+- Date: 18 December, 2019 at 16:30 - 20:00
+- Meetup link: https://www.meetup.com/Cloud-Native-Aarhus/events/266225252
+
+#### Agenda
+
+
+### Istio in Production & Storage in k8s
+
+- Date: 14 November, 2019 at 17:00 - 20:00
+- Meetup link: https://www.meetup.com/Cloud-Native-Aarhus/events/265871741
+
+#### Agenda
+
+
 ### Chaos Engineering with Russ Miles & KubeOne with Alexander Sowitzki
 
 - Date: 22 October, 2019 at 17:00 - 20:00

--- a/aarhus/meetup.yaml
+++ b/aarhus/meetup.yaml
@@ -767,6 +767,14 @@ meetups:
       role: Venue
     - company: teamblue
       role: Food
+  "20191114":
+    presentations: null
+    recording: ""
+    sponsors: null
+  "20191218":
+    presentations: null
+    recording: ""
+    sponsors: null
 organizers:
 - kaspernissen
 - rasmussteiniche

--- a/bergen/README.md
+++ b/bergen/README.md
@@ -1,6 +1,6 @@
 # Meetups organized in Bergen
 
-<img width="50%" align="right" alt="Meetup Group Logo" src="https://secure.meetupstatic.com/photos/event/2/4/0/0/highres_485769216.jpeg">
+<img width="50%" align="right" alt="Meetup Group Logo" src="https://secure.meetupstatic.com/photos/event/c/a/5/f/highres_486471807.jpeg">
 
 ## Description
 

--- a/bergen/README.md
+++ b/bergen/README.md
@@ -11,6 +11,14 @@
 
 - Hans Kristian Flaatten [@starefossen](https://github.com/starefossen), DevOps Practice Lead, [EVRY](https://www.evry.com/en/)
 
+### Cloud Native Nordics Tour
+
+- Date: 23 January, 2020 at 17:30 - 20:30
+- Meetup link: https://www.meetup.com/cloudnative-bergen/events/266338983
+
+#### Agenda
+
+
 ### Serverless on AWS
 
 - Date: 6 November, 2019 at 17:30 - 20:00

--- a/bergen/meetup.yaml
+++ b/bergen/meetup.yaml
@@ -109,5 +109,9 @@ meetups:
     sponsors:
     - company: evry
       role: Venue
+  "20200123":
+    presentations: null
+    recording: ""
+    sponsors: null
 organizers:
 - starefossen

--- a/config.json
+++ b/config.json
@@ -1814,6 +1814,29 @@
               "speakers": null
             }
           ]
+        },
+        "20191106": {
+          "id": 263745012,
+          "photo": "https://secure.meetupstatic.com/photos/event/8/4/e/e/highres_486394030.jpeg",
+          "name": "#3 Observability II",
+          "date": "2019-11-06T16:30:00Z",
+          "duration": "3h0m0s",
+          "attendees": 33,
+          "address": "Skelagervej 15",
+          "recording": "",
+          "sponsors": null,
+          "presentations": null
+        },
+        "20191211": {
+          "id": 265893647,
+          "photo": "https://secure.meetupstatic.com/photos/event/6/a/6/8/highres_486447240.jpeg",
+          "name": "#4 Istio in production, Prometheus 101 and Gitops",
+          "date": "2019-12-11T16:45:00Z",
+          "duration": "3h15m0s",
+          "address": "Skelagervej 1",
+          "recording": "",
+          "sponsors": null,
+          "presentations": null
         }
       }
     },
@@ -3233,6 +3256,28 @@
               ]
             }
           ]
+        },
+        "20191114": {
+          "id": 265871741,
+          "photo": "https://secure.meetupstatic.com/photos/event/2/8/2/9/highres_486190281.jpeg",
+          "name": "Istio in Production \u0026 Storage in k8s",
+          "date": "2019-11-14T17:00:00Z",
+          "duration": "3h0m0s",
+          "address": "Højvangen 4",
+          "recording": "",
+          "sponsors": null,
+          "presentations": null
+        },
+        "20191218": {
+          "id": 266225252,
+          "photo": "https://secure.meetupstatic.com/photos/event/7/3/4/1/highres_486569505.jpeg",
+          "name": "Happy Holidays Edition with GitOps and Exploiting the winds of change",
+          "date": "2019-12-18T16:30:00Z",
+          "duration": "3h30m0s",
+          "address": "Finlandsgade 28",
+          "recording": "",
+          "sponsors": null,
+          "presentations": null
         }
       }
     },
@@ -3484,6 +3529,17 @@
               ]
             }
           ]
+        },
+        "20200123": {
+          "id": 266338983,
+          "photo": "https://secure.meetupstatic.com/photos/event/2/e/d/c/highres_486491996.jpeg",
+          "name": "Cloud Native Nordics Tour",
+          "date": "2020-01-23T17:30:00Z",
+          "duration": "3h0m0s",
+          "address": "Folke Bernadottes vei 40",
+          "recording": "",
+          "sponsors": null,
+          "presentations": null
         }
       }
     },
@@ -3947,6 +4003,17 @@
           "recording": "",
           "sponsors": null,
           "presentations": null
+        },
+        "20191210": {
+          "id": 266225732,
+          "photo": "https://secure.meetupstatic.com/photos/event/8/8/6/2/highres_486394914.jpeg",
+          "name": "GitOps \u0026 Serverless",
+          "date": "2019-12-10T17:00:00Z",
+          "duration": "3h0m0s",
+          "address": "Kongens Nytorv 18",
+          "recording": "",
+          "sponsors": null,
+          "presentations": null
         }
       }
     },
@@ -4133,6 +4200,16 @@
           "duration": "3h0m0s",
           "attendees": 70,
           "address": "Vallgatan 22",
+          "recording": "",
+          "sponsors": null,
+          "presentations": null
+        },
+        "20191204": {
+          "id": 265686037,
+          "name": "Local Kubernetes - more details closer to event",
+          "date": "2019-12-04T18:00:00Z",
+          "duration": "3h0m0s",
+          "address": "",
           "recording": "",
           "sponsors": null,
           "presentations": null
@@ -5236,6 +5313,16 @@
           "recording": "",
           "sponsors": null,
           "presentations": null
+        },
+        "20191113": {
+          "id": 265737238,
+          "name": "Storage Operator in Kubernetes - Getting your Feet Wet",
+          "date": "2019-11-13T17:15:00Z",
+          "duration": "2h0m0s",
+          "address": "Pilestredet 56",
+          "recording": "",
+          "sponsors": null,
+          "presentations": null
         }
       }
     },
@@ -5994,6 +6081,17 @@
               ]
             }
           ]
+        },
+        "20191204": {
+          "id": 266223857,
+          "photo": "https://secure.meetupstatic.com/photos/event/8/2/6/b/highres_486453387.jpeg",
+          "name": "December Kubernetes Meetup in Tampere",
+          "date": "2019-12-04T17:00:00Z",
+          "duration": "3h0m0s",
+          "address": "Hatanpään valtatie 30",
+          "recording": "",
+          "sponsors": null,
+          "presentations": null
         }
       }
     },
@@ -6256,6 +6354,17 @@
               ]
             }
           ]
+        },
+        "20191125": {
+          "id": 266254756,
+          "photo": "https://secure.meetupstatic.com/photos/event/1/3/8/8/highres_486425000.jpeg",
+          "name": "KubeCon recap \u0026 Istio",
+          "date": "2019-11-25T17:00:00Z",
+          "duration": "2h0m0s",
+          "address": "Kuratorvägen 2A",
+          "recording": "",
+          "sponsors": null,
+          "presentations": null
         }
       }
     }

--- a/config.json
+++ b/config.json
@@ -3237,7 +3237,7 @@
       }
     },
     {
-      "photo": "https://secure.meetupstatic.com/photos/event/2/4/0/0/highres_485769216.jpeg",
+      "photo": "https://secure.meetupstatic.com/photos/event/c/a/5/f/highres_486471807.jpeg",
       "name": "DevOps and Cloud Native Bergen",
       "city": "Bergen",
       "country": "norway",
@@ -4144,7 +4144,7 @@
       "name": "Kubernetes and CNCF Finland Meetup",
       "city": "Helsinki",
       "country": "finland",
-      "description": "\u003cp\u003eCloud Native tech and Kubernetes goes Helsinki! Cloud Native and Kubernetes Helsinki is the official Cloud Native Computing Foundation Meetup group about the technologies hosted under CNCF umbrella: \u003cbr\u003e- Kubernetes \u003cbr\u003e- Prometheus \u003cbr\u003e- Opentracing \u003cbr\u003e- Fluentd \u003cbr\u003e- CoreDNS \u003cbr\u003e- linkerd \u003cbr\u003e- containerd \u003cbr\u003e- rkt \u003cbr\u003e- gRPC \u003cbr\u003e- CNI\u003c/p\u003e\n\u003cp\u003eWe host talks from anyone doing cool things with Kubernetes, and the other CNCF technologies, including companies using them in production or vendors who are pushing the boundaries of what the cloud native techs can do.\u003c/p\u003e\n\u003cp\u003ePresentations will be focused on introduction slides, guides, workshops, adoption stories and demos, but not sales pitches. The meetup will be organized in an open and democratic way, where anyone that wants to help out organizing or speaking will be truly welcome.\u003c/p\u003e\n\u003cp\u003eTo become an organizer or speaker, please reach out to us!\u003c/p\u003e\n\u003cp\u003e This meetup's official language is English; the conversations and presentations will be in English.\u003c/p\u003e\n\u003cp\u003eFor more information, check out the blog at \u003ca href=\"https://kubernetesfinland.com\" class=\"linkified\"\u003ehttps://kubernetesfinland.com\u003c/a\u003e\u003c/p\u003e",
+      "description": "\u003cp\u003eCloud Native tech and Kubernetes goes Helsinki! Cloud Native and Kubernetes Helsinki is the official Cloud Native Computing Foundation Meetup group about the technologies hosted under CNCF umbrella: \u0026lt;br\u0026gt;- Kubernetes \u0026lt;br\u0026gt;- Prometheus \u0026lt;br\u0026gt;- Opentracing \u0026lt;br\u0026gt;- Fluentd \u0026lt;br\u0026gt;- CoreDNS \u0026lt;br\u0026gt;- linkerd \u0026lt;br\u0026gt;- containerd \u0026lt;br\u0026gt;- rkt \u0026lt;br\u0026gt;- gRPC \u0026lt;br\u0026gt;- CNI\u003c/p\u003e \n\u003cp\u003eWe host talks from anyone doing cool things with Kubernetes, and the other CNCF technologies, including companies using them in production or vendors who are pushing the boundaries of what the cloud native techs can do.\u003c/p\u003e \n\u003cp\u003ePresentations will be focused on introduction slides, guides, workshops, adoption stories and demos, but not sales pitches. The meetup will be organized in an open and democratic way, where anyone that wants to help out organizing or speaking will be truly welcome.\u003c/p\u003e \n\u003cp\u003eTo become an organizer or speaker, please reach out to us!\u003c/p\u003e \n\u003cp\u003eThis meetup's official language is English; the conversations and presentations will be in English.\u003c/p\u003e \n\u003cp\u003eFor more information, check out the blog at \u003ca href=\"https://kubernetesfinland.com\" class=\"linkified\"\u003ehttps://kubernetesfinland.com\u003c/a\u003e\u003c/p\u003e",
       "sponsorTiers": {
         "accenture": "Meetup",
         "agileo": "EcosystemMember",

--- a/copenhagen/README.md
+++ b/copenhagen/README.md
@@ -14,6 +14,14 @@
 - Jeppe Johansen [@jepp2078](https://github.com/jepp2078), Head of Software Engineering, [Whyyy](https://whyyy.dk/), [Contact](https://www.cncf.io/speaker/jepp2078)
 - Hans Duedal [@duedal](https://github.com/duedal), [Unity](https://www.unity.com)
 
+### GitOps & Serverless
+
+- Date: 10 December, 2019 at 17:00 - 20:00
+- Meetup link: https://www.meetup.com/Cloud-Native-Copenhagen/events/266225732
+
+#### Agenda
+
+
 ### Chaos Engineering, Istio & KubeOne
 
 - Date: 21 October, 2019 at 17:00 - 20:00

--- a/copenhagen/meetup.yaml
+++ b/copenhagen/meetup.yaml
@@ -225,6 +225,10 @@ meetups:
     presentations: null
     recording: ""
     sponsors: null
+  "20191210":
+    presentations: null
+    recording: ""
+    sponsors: null
 organizers:
 - laszlo
 - jasmine

--- a/göteborg/README.md
+++ b/göteborg/README.md
@@ -16,6 +16,14 @@
 - Anton Lindgren, [Yolean](https://www.yolean.com/)
 - Jacob Hagstedt P Suorra [@Jacobh2](https://github.com/Jacobh2)
 
+### Local Kubernetes - more details closer to event
+
+- Date: 4 December, 2019 at 18:00 - 21:00
+- Meetup link: https://www.meetup.com/Kubernetes-Goteborg/events/265686037
+
+#### Agenda
+
+
 ### September meetup in Gothenburg
 
 - Date: 5 September, 2019 at 18:00 - 21:00

--- a/göteborg/meetup.yaml
+++ b/göteborg/meetup.yaml
@@ -77,6 +77,10 @@ meetups:
     presentations: null
     recording: ""
     sponsors: null
+  "20191204":
+    presentations: null
+    recording: ""
+    sponsors: null
 organizers:
 - jessicaandersson
 - staffanolsson

--- a/helsinki/README.md
+++ b/helsinki/README.md
@@ -4,11 +4,11 @@
 
 ## Description
 
-<p>Cloud Native tech and Kubernetes goes Helsinki! Cloud Native and Kubernetes Helsinki is the official Cloud Native Computing Foundation Meetup group about the technologies hosted under CNCF umbrella: <br>- Kubernetes <br>- Prometheus <br>- Opentracing <br>- Fluentd <br>- CoreDNS <br>- linkerd <br>- containerd <br>- rkt <br>- gRPC <br>- CNI</p>
-<p>We host talks from anyone doing cool things with Kubernetes, and the other CNCF technologies, including companies using them in production or vendors who are pushing the boundaries of what the cloud native techs can do.</p>
-<p>Presentations will be focused on introduction slides, guides, workshops, adoption stories and demos, but not sales pitches. The meetup will be organized in an open and democratic way, where anyone that wants to help out organizing or speaking will be truly welcome.</p>
-<p>To become an organizer or speaker, please reach out to us!</p>
-<p> This meetup's official language is English; the conversations and presentations will be in English.</p>
+<p>Cloud Native tech and Kubernetes goes Helsinki! Cloud Native and Kubernetes Helsinki is the official Cloud Native Computing Foundation Meetup group about the technologies hosted under CNCF umbrella: &lt;br&gt;- Kubernetes &lt;br&gt;- Prometheus &lt;br&gt;- Opentracing &lt;br&gt;- Fluentd &lt;br&gt;- CoreDNS &lt;br&gt;- linkerd &lt;br&gt;- containerd &lt;br&gt;- rkt &lt;br&gt;- gRPC &lt;br&gt;- CNI</p> 
+<p>We host talks from anyone doing cool things with Kubernetes, and the other CNCF technologies, including companies using them in production or vendors who are pushing the boundaries of what the cloud native techs can do.</p> 
+<p>Presentations will be focused on introduction slides, guides, workshops, adoption stories and demos, but not sales pitches. The meetup will be organized in an open and democratic way, where anyone that wants to help out organizing or speaking will be truly welcome.</p> 
+<p>To become an organizer or speaker, please reach out to us!</p> 
+<p>This meetup's official language is English; the conversations and presentations will be in English.</p> 
 <p>For more information, check out the blog at <a href="https://kubernetesfinland.com" class="linkified">https://kubernetesfinland.com</a></p>
 
 ## Submit a talk

--- a/oslo/README.md
+++ b/oslo/README.md
@@ -16,6 +16,14 @@
 - Sami Alajrami [@sami](https://github.com/sami), [Praqma](https://www.praqma.com/)
 - Audun Fauchald Strand [@audunstrand](https://github.com/audunstrand), [Nav](https://www.nav.no/Forsiden)
 
+### Storage Operator in Kubernetes - Getting your Feet Wet
+
+- Date: 13 November, 2019 at 17:15 - 19:15
+- Meetup link: https://www.meetup.com/Cloud-Native-and-Kubernetes-Oslo/events/265737238
+
+#### Agenda
+
+
 ### GitOps your kubernetes deployments with Helm and Helmsman
 
 - Date: 29 November, 2018 at 17:00 - 19:00

--- a/oslo/meetup.yaml
+++ b/oslo/meetup.yaml
@@ -36,6 +36,10 @@ meetups:
     presentations: null
     recording: ""
     sponsors: null
+  "20191113":
+    presentations: null
+    recording: ""
+    sponsors: null
 organizers:
 - sami
 - audunstrand

--- a/stats.json
+++ b/stats.json
@@ -4,7 +4,7 @@
     "sponsors": 117,
     "speakers": 125,
     "meetups": 92,
-    "members": 5631,
+    "members": 5654,
     "totalRSVPs": 4774,
     "averageRSVPs": 51,
     "uniqueRSVPs": 2658
@@ -31,7 +31,7 @@
       },
       "speakers": 41,
       "meetups": 24,
-      "members": 933,
+      "members": 936,
       "totalRSVPs": 1356,
       "averageRSVPs": 56,
       "uniqueRSVPs": 533
@@ -43,7 +43,7 @@
       },
       "speakers": 5,
       "meetups": 8,
-      "members": 204,
+      "members": 206,
       "totalRSVPs": 147,
       "averageRSVPs": 18,
       "uniqueRSVPs": 89
@@ -56,7 +56,7 @@
       },
       "speakers": 11,
       "meetups": 13,
-      "members": 835,
+      "members": 840,
       "totalRSVPs": 670,
       "averageRSVPs": 51,
       "uniqueRSVPs": 405
@@ -68,7 +68,7 @@
       },
       "speakers": 5,
       "meetups": 9,
-      "members": 522,
+      "members": 523,
       "totalRSVPs": 271,
       "averageRSVPs": 30,
       "uniqueRSVPs": 179
@@ -82,7 +82,7 @@
       },
       "speakers": 26,
       "meetups": 11,
-      "members": 870,
+      "members": 873,
       "totalRSVPs": 888,
       "averageRSVPs": 80,
       "uniqueRSVPs": 452
@@ -94,7 +94,7 @@
       },
       "speakers": 0,
       "meetups": 8,
-      "members": 749,
+      "members": 754,
       "totalRSVPs": 364,
       "averageRSVPs": 45,
       "uniqueRSVPs": 243
@@ -132,7 +132,7 @@
       },
       "speakers": 14,
       "meetups": 5,
-      "members": 193,
+      "members": 194,
       "totalRSVPs": 200,
       "averageRSVPs": 40,
       "uniqueRSVPs": 114
@@ -145,7 +145,7 @@
       },
       "speakers": 5,
       "meetups": 1,
-      "members": 72,
+      "members": 73,
       "totalRSVPs": 49,
       "averageRSVPs": 49,
       "uniqueRSVPs": 49
@@ -158,7 +158,7 @@
       },
       "speakers": 4,
       "meetups": 4,
-      "members": 140,
+      "members": 142,
       "totalRSVPs": 145,
       "averageRSVPs": 36,
       "uniqueRSVPs": 83

--- a/stats.json
+++ b/stats.json
@@ -3,11 +3,11 @@
   "allMeetups": {
     "sponsors": 117,
     "speakers": 125,
-    "meetups": 92,
+    "meetups": 93,
     "members": 5654,
-    "totalRSVPs": 4774,
+    "totalRSVPs": 4807,
     "averageRSVPs": 51,
-    "uniqueRSVPs": 2658
+    "uniqueRSVPs": 2668
   },
   "perMeetup": {
     "aalborg": {
@@ -17,11 +17,11 @@
         "SpeakerProvider": 3
       },
       "speakers": 6,
-      "meetups": 2,
+      "meetups": 3,
       "members": 132,
-      "totalRSVPs": 104,
-      "averageRSVPs": 52,
-      "uniqueRSVPs": 77
+      "totalRSVPs": 137,
+      "averageRSVPs": 45,
+      "uniqueRSVPs": 87
     },
     "aarhus": {
       "sponsors": 33,

--- a/tampere/README.md
+++ b/tampere/README.md
@@ -19,6 +19,14 @@ If you're interested in speaking in this meetup, fill out this form: https://bit
 - Jussi Nummelin [@jnummelin](https://github.com/jnummelin), [Kontena](https://kontena.io)
 - Toni Ylenius [@toddnni](https://github.com/toddnni), [Cybercom](https://www.cybercom.com/)
 
+### December Kubernetes Meetup in Tampere
+
+- Date: 4 December, 2019 at 17:00 - 20:00
+- Meetup link: https://www.meetup.com/Kubernetes-Tampere/events/266223857
+
+#### Agenda
+
+
 ### Kubernetes 101 Hands-On Workshop
 
 - Date: 29 October, 2019 at 17:00 - 21:00

--- a/tampere/meetup.yaml
+++ b/tampere/meetup.yaml
@@ -224,6 +224,10 @@ meetups:
       role: Other
     - company: digitalocean
       role: Other
+  "20191204":
+    presentations: null
+    recording: ""
+    sponsors: null
 organizers:
 - luxas
 - netumoliver

--- a/umeå/README.md
+++ b/umeå/README.md
@@ -16,6 +16,14 @@
 - Erik Lindskog [@cartmanume](https://github.com/cartmanume), [Codemill](https://codemill.se/)
 - Johan Tordsson [@tordsson](https://github.com/tordsson), [Elastisys](https://elastisys.com/)
 
+### KubeCon recap & Istio
+
+- Date: 25 November, 2019 at 17:00 - 19:00
+- Meetup link: https://www.meetup.com/Cloud-Native-Northern-Sweden/events/266254756
+
+#### Agenda
+
+
 ### Trends in cloud native - a summary from KubeCon + CloudNativeCon Barcelona 
 
 - Date: 28 May, 2019 at 17:00 - 19:00

--- a/umeå/meetup.yaml
+++ b/umeå/meetup.yaml
@@ -54,6 +54,10 @@ meetups:
     sponsors:
     - company: elastisys
       role: Venue
+  "20191125":
+    presentations: null
+    recording: ""
+    sponsors: null
 organizers:
 - robertwinter
 - eriklindskog


### PR DESCRIPTION
Eventually,
a) we should create some kind of pinging mechanism for organizers to remember to fill in this data (most is autogenerated)
b) the generator should automatically detect these "blank" meetups and include it in the stats-api by default

With these blank meetups, these meetups will show up on https://cloudnativenordics.com/events
cc @kaspernissen 