### PR TITLE
Update Finnish data

### DIFF
--- a/aalborg/README.md
+++ b/aalborg/README.md
@@ -20,6 +20,7 @@
 
 - Date: 11 December, 2019 at 16:45 - 20:00
 - Meetup link: https://www.meetup.com/Cloud-Native-Aalborg/events/265893647
+- Attendees (according to meetup.com): 41
 - Venue sponsor: [Centrica Energy Trading](https://www.centrica.com/)
 
 #### Agenda

--- a/aarhus/README.md
+++ b/aarhus/README.md
@@ -19,6 +19,7 @@
 
 - Date: 18 December, 2019 at 16:30 - 20:00
 - Meetup link: https://www.meetup.com/Cloud-Native-Aarhus/events/266225252
+- Attendees (according to meetup.com): 44
 
 #### Agenda
 

--- a/config.json
+++ b/config.json
@@ -1981,6 +1981,7 @@
           "name": "#4 Istio in production, Prometheus 101 and Gitops",
           "date": "2019-12-11T16:45:00Z",
           "duration": "3h15m0s",
+          "attendees": 41,
           "address": "Skelagervej 1",
           "recording": "",
           "sponsors": [
@@ -3428,6 +3429,7 @@
           "name": "Happy Holidays Edition with GitOps and Exploiting the winds of change",
           "date": "2019-12-18T16:30:00Z",
           "duration": "3h30m0s",
+          "attendees": 44,
           "address": "Finlandsgade 28",
           "recording": "",
           "sponsors": null,
@@ -6440,6 +6442,7 @@
           "name": "December Meetup in Turku",
           "date": "2019-12-12T17:00:00Z",
           "duration": "3h0m0s",
+          "attendees": 23,
           "address": "Linnankatu 16",
           "recording": "",
           "sponsors": [

--- a/config.json
+++ b/config.json
@@ -5263,7 +5263,7 @@
           "duration": "3h0m0s",
           "attendees": 103,
           "address": "Karasvängen 7",
-          "recording": "",
+          "recording": "https://youtu.be/Yxk-mY-V3Vk",
           "sponsors": [
             {
               "role": "Venue",
@@ -5347,7 +5347,7 @@
           "duration": "3h0m0s",
           "attendees": 62,
           "address": "Westendgatan 7",
-          "recording": "",
+          "recording": "https://youtu.be/S9WJnhi3moM",
           "sponsors": [
             {
               "role": "Venue",
@@ -5378,7 +5378,7 @@
             {
               "duration": "15m0s",
               "title": "KubeCon Recap and Community Updates",
-              "slides": "",
+              "slides": "https://speakerdeck.com/luxas/kubernetes-and-cncf-meetup-helsinki-november-2019",
               "speakers": [
                 "luxas"
               ]
@@ -5402,7 +5402,7 @@
             {
               "duration": "30m0s",
               "title": "All Meshed Up - How we use Linkerd",
-              "slides": "",
+              "slides": "https://speakerdeck.com/sachinkundu/linkerd2-at-cncf-finland",
               "speakers": [
                 "sachinkundu"
               ]
@@ -5411,7 +5411,7 @@
               "duration": "30m0s",
               "delay": "10m0s",
               "title": "Cloud Native Components in VTT's Data Pipelines",
-              "slides": "",
+              "slides": "https://speakerdeck.com/hazsetata/cloud-native-components-in-vtts-data-pipelines",
               "speakers": [
                 "zsolthomorodi"
               ]
@@ -5424,6 +5424,17 @@
               "speakers": null
             }
           ]
+        },
+        "20200120": {
+          "id": 267110169,
+          "photo": "https://secure.meetupstatic.com/photos/event/4/a/c/highres_487321196.jpeg",
+          "name": "January Meetup in Helsinki",
+          "date": "2020-01-20T18:00:00Z",
+          "duration": "3h0m0s",
+          "address": "Postrutten 7",
+          "recording": "https://youtu.be/3k5EfIQpw-E",
+          "sponsors": null,
+          "presentations": null
         }
       }
     },
@@ -5898,7 +5909,6 @@
       "sponsorTiers": {
         "cncf": "Meetup",
         "cybercom": "Meetup",
-        "digitalocean": "Meetup",
         "eficode": "Meetup",
         "futurice": "Meetup",
         "intel": "SpeakerProvider",
@@ -5909,7 +5919,8 @@
         "polarsquad": "SpeakerProvider",
         "redhat": "SpeakerProvider",
         "storaenso": "SpeakerProvider",
-        "tribe": "Meetup"
+        "tribe": "Meetup",
+        "weaveworks": "Meetup"
       },
       "meetupID": "Kubernetes-Tampere",
       "organizers": [
@@ -6275,7 +6286,7 @@
           "duration": "4h0m0s",
           "attendees": 4,
           "address": "Åkerlundinkatu 11 A",
-          "recording": "",
+          "recording": "https://www.youtube.com/watch?v=FcUY7Gv94J8",
           "sponsors": [
             {
               "role": "Venue",
@@ -6291,7 +6302,7 @@
             },
             {
               "role": "Other",
-              "company": "digitalocean"
+              "company": "weaveworks"
             }
           ],
           "presentations": [
@@ -6356,7 +6367,7 @@
           "duration": "3h0m0s",
           "attendees": 49,
           "address": "Lemminkäisenkatu 14B",
-          "recording": "",
+          "recording": "https://youtu.be/eyTv2uBL3ag",
           "sponsors": [
             {
               "role": "Venue",
@@ -6422,7 +6433,7 @@
               "duration": "30m0s",
               "delay": "10m0s",
               "title": "All Meshed Up - How we use Linkerd",
-              "slides": "",
+              "slides": "https://speakerdeck.com/sachinkundu/linkerd2-at-cncf-finland",
               "speakers": [
                 "sachinkundu"
               ]
@@ -6444,7 +6455,7 @@
           "duration": "3h0m0s",
           "attendees": 23,
           "address": "Linnankatu 16",
-          "recording": "",
+          "recording": "https://youtu.be/VoQU2uvHY8w",
           "sponsors": [
             {
               "role": "Venue",

--- a/helsinki/README.md
+++ b/helsinki/README.md
@@ -20,10 +20,20 @@ If you're interested in speaking in this meetup, fill out this form: https://bit
 - Lucas Käldström [@luxas](https://github.com/luxas), CNCF Ambassador, [luxas labs](https://luxaslabs.com), [Contact](https://www.cncf.io/speaker/luxas)
 - Annie Talvasto [@Ani000](https://github.com/Ani000), [Microsoft](https://www.microsoft.com)
 
+### January Meetup in Helsinki
+
+- Date: 20 January, 2020 at 18:00 - 21:00
+- Meetup link: https://www.meetup.com/Kubernetes-Finland/events/267110169
+- Recording: https://youtu.be/3k5EfIQpw-E
+
+#### Agenda
+
+
 ### KubeCon Recap & Linkerd Deep Dive
 
 - Date: 28 November, 2019 at 18:00 - 21:00
 - Meetup link: https://www.meetup.com/Kubernetes-Finland/events/265529376
+- Recording: https://youtu.be/S9WJnhi3moM
 - Attendees (according to meetup.com): 62
 - Venue sponsor: [Intel](https://www.intel.com)
 - Other sponsor: [luxas labs](https://luxaslabs.com)
@@ -35,6 +45,7 @@ If you're interested in speaking in this meetup, fill out this form: https://bit
 - 18:10 - 18:15: Introductionary words from the venue sponsor for this time, Intel 
 - 18:15 - 18:30: KubeCon Recap and Community Updates 
   - Lucas Käldström [@luxas](https://github.com/luxas), CNCF Ambassador, [luxas labs](https://luxaslabs.com), [Contact](https://www.cncf.io/speaker/luxas)
+  - Slides: https://speakerdeck.com/luxas/kubernetes-and-cncf-meetup-helsinki-november-2019
 - 18:30 - 19:00: Be smarter, get more out of your clusters 
   - Eero Tamminen, [Intel](https://www.intel.com)
   - Ismo Puustinen [@ipuustin](https://github.com/ipuustin), [Intel](https://www.intel.com)
@@ -42,14 +53,17 @@ If you're interested in speaking in this meetup, fill out this form: https://bit
 - 19:00 - 19:30: Networking, food, drinks 
 - 19:30 - 20:00: All Meshed Up - How we use Linkerd 
   - Sachin Kundu [@sachinkundu](https://github.com/sachinkundu), [Microsoft](https://www.microsoft.com)
+  - Slides: https://speakerdeck.com/sachinkundu/linkerd2-at-cncf-finland
 - 20:10 - 20:40: Cloud Native Components in VTT's Data Pipelines 
   - Zsolt Homorodi [@hazsetata](https://github.com/hazsetata), [VTT](https://www.vtt.fi/)
+  - Slides: https://speakerdeck.com/hazsetata/cloud-native-components-in-vtts-data-pipelines
 - 20:45 - 21:00: Networking 
 
 ### October: Chaos Engineering & KubeOne
 
 - Date: 24 October, 2019 at 18:00 - 21:00
 - Meetup link: https://www.meetup.com/Kubernetes-Finland/events/264646130
+- Recording: https://youtu.be/Yxk-mY-V3Vk
 - Attendees (according to meetup.com): 103
 - Venue sponsor: [Nokia](https://www.nokia.com/)
 - Other sponsor: [luxas labs](https://luxaslabs.com)

--- a/helsinki/meetup.yaml
+++ b/helsinki/meetup.yaml
@@ -529,7 +529,7 @@ meetups:
       slides: ""
       speakers: null
       title: Networking
-    recording: ""
+    recording: https://youtu.be/Yxk-mY-V3Vk
     sponsors:
     - company: nokia
       role: Venue
@@ -548,7 +548,7 @@ meetups:
       speakers: null
       title: Introductionary words from the venue sponsor for this time, Intel
     - duration: 15m0s
-      slides: ""
+      slides: https://speakerdeck.com/luxas/kubernetes-and-cncf-meetup-helsinki-november-2019
       speakers:
       - luxas
       title: KubeCon Recap and Community Updates
@@ -564,13 +564,13 @@ meetups:
       speakers: null
       title: Networking, food, drinks
     - duration: 30m0s
-      slides: ""
+      slides: https://speakerdeck.com/sachinkundu/linkerd2-at-cncf-finland
       speakers:
       - sachinkundu
       title: All Meshed Up - How we use Linkerd
     - delay: 10m0s
       duration: 30m0s
-      slides: ""
+      slides: https://speakerdeck.com/hazsetata/cloud-native-components-in-vtts-data-pipelines
       speakers:
       - zsolthomorodi
       title: Cloud Native Components in VTT's Data Pipelines
@@ -579,7 +579,7 @@ meetups:
       slides: ""
       speakers: null
       title: Networking
-    recording: ""
+    recording: https://youtu.be/S9WJnhi3moM
     sponsors:
     - company: intel
       role: Venue
@@ -587,6 +587,10 @@ meetups:
       role: Other
     - company: cncf
       role: Other
+  "20200120":
+    presentations: null
+    recording: https://youtu.be/3k5EfIQpw-E
+    sponsors: null
 organizers:
 - luxas
 - annie

--- a/stats.json
+++ b/stats.json
@@ -2,12 +2,12 @@
   "meetupGroups": 12,
   "allMeetups": {
     "sponsors": 122,
-    "speakers": 132,
-    "meetups": 100,
-    "members": 5926,
-    "totalRSVPs": 5145,
+    "speakers": 134,
+    "meetups": 103,
+    "members": 5999,
+    "totalRSVPs": 5253,
     "averageRSVPs": 51,
-    "uniqueRSVPs": 2808
+    "uniqueRSVPs": 2828
   },
   "perMeetup": {
     "aalborg": {
@@ -17,11 +17,11 @@
         "SpeakerProvider": 4
       },
       "speakers": 9,
-      "meetups": 3,
-      "members": 151,
-      "totalRSVPs": 137,
-      "averageRSVPs": 45,
-      "uniqueRSVPs": 87
+      "meetups": 4,
+      "members": 158,
+      "totalRSVPs": 178,
+      "averageRSVPs": 44,
+      "uniqueRSVPs": 96
     },
     "aarhus": {
       "sponsors": 33,
@@ -30,11 +30,11 @@
         "SpeakerProvider": 15
       },
       "speakers": 41,
-      "meetups": 25,
-      "members": 958,
-      "totalRSVPs": 1412,
+      "meetups": 26,
+      "members": 965,
+      "totalRSVPs": 1456,
       "averageRSVPs": 56,
-      "uniqueRSVPs": 552
+      "uniqueRSVPs": 560
     },
     "bergen": {
       "sponsors": 1,
@@ -43,7 +43,7 @@
       },
       "speakers": 5,
       "meetups": 8,
-      "members": 212,
+      "members": 214,
       "totalRSVPs": 147,
       "averageRSVPs": 18,
       "uniqueRSVPs": 89
@@ -56,10 +56,10 @@
       },
       "speakers": 11,
       "meetups": 14,
-      "members": 887,
+      "members": 909,
       "totalRSVPs": 730,
       "averageRSVPs": 52,
-      "uniqueRSVPs": 431
+      "uniqueRSVPs": 430
     },
     "göteborg": {
       "sponsors": 3,
@@ -68,7 +68,7 @@
       },
       "speakers": 5,
       "meetups": 10,
-      "members": 569,
+      "members": 574,
       "totalRSVPs": 321,
       "averageRSVPs": 32,
       "uniqueRSVPs": 204
@@ -82,7 +82,7 @@
       },
       "speakers": 30,
       "meetups": 12,
-      "members": 919,
+      "members": 928,
       "totalRSVPs": 950,
       "averageRSVPs": 79,
       "uniqueRSVPs": 474
@@ -94,7 +94,7 @@
       },
       "speakers": 0,
       "meetups": 9,
-      "members": 768,
+      "members": 770,
       "totalRSVPs": 392,
       "averageRSVPs": 43,
       "uniqueRSVPs": 255
@@ -107,7 +107,7 @@
       },
       "speakers": 8,
       "meetups": 3,
-      "members": 236,
+      "members": 237,
       "totalRSVPs": 128,
       "averageRSVPs": 42,
       "uniqueRSVPs": 97
@@ -119,7 +119,7 @@
       },
       "speakers": 0,
       "meetups": 4,
-      "members": 787,
+      "members": 803,
       "totalRSVPs": 452,
       "averageRSVPs": 113,
       "uniqueRSVPs": 335
@@ -132,7 +132,7 @@
       },
       "speakers": 14,
       "meetups": 6,
-      "members": 203,
+      "members": 205,
       "totalRSVPs": 244,
       "averageRSVPs": 40,
       "uniqueRSVPs": 131
@@ -143,12 +143,12 @@
         "Meetup": 6,
         "SpeakerProvider": 2
       },
-      "speakers": 5,
-      "meetups": 1,
+      "speakers": 7,
+      "meetups": 2,
       "members": 78,
-      "totalRSVPs": 49,
-      "averageRSVPs": 49,
-      "uniqueRSVPs": 49
+      "totalRSVPs": 72,
+      "averageRSVPs": 36,
+      "uniqueRSVPs": 53
     },
     "umeå": {
       "sponsors": 4,

--- a/tampere/README.md
+++ b/tampere/README.md
@@ -32,11 +32,12 @@ If you're interested in speaking in this meetup, fill out this form: https://bit
 
 - Date: 29 October, 2019 at 17:00 - 21:00
 - Meetup link: https://www.meetup.com/Kubernetes-Tampere/events/265150836
+- Recording: https://www.youtube.com/watch?v=FcUY7Gv94J8
 - Attendees (according to meetup.com): 4
 - Venue sponsor: [Eficode](https://www.eficode.com/home)
 - Other sponsor: [luxas labs](https://luxaslabs.com)
 - Other sponsor: [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/)
-- Other sponsor: [Digital Ocean](https://www.digitalocean.com/)
+- Other sponsor: [Weaveworks](https://www.weave.works)
 
 #### Agenda
 

--- a/tampere/meetup.yaml
+++ b/tampere/meetup.yaml
@@ -214,7 +214,7 @@ meetups:
       speakers:
       - luxas
       title: Kubernetes 101 Hands-On Workshop
-    recording: ""
+    recording: https://www.youtube.com/watch?v=FcUY7Gv94J8
     sponsors:
     - company: eficode
       role: Venue
@@ -222,7 +222,7 @@ meetups:
       role: Other
     - company: cncf
       role: Other
-    - company: digitalocean
+    - company: weaveworks
       role: Other
   "20191204":
     presentations: null

--- a/turku/README.md
+++ b/turku/README.md
@@ -26,6 +26,7 @@ If you're interested in speaking in this meetup, fill out this form: https://bit
 
 - Date: 12 December, 2019 at 17:00 - 20:00
 - Meetup link: https://www.meetup.com/Kubernetes-Turku/events/265794322
+- Attendees (according to meetup.com): 23
 - Venue sponsor: [Reaktor](https://www.reaktor.com/)
 - Other sponsor: [luxas labs](https://luxaslabs.com)
 - Other sponsor: [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/)

--- a/turku/README.md
+++ b/turku/README.md
@@ -26,6 +26,7 @@ If you're interested in speaking in this meetup, fill out this form: https://bit
 
 - Date: 12 December, 2019 at 17:00 - 20:00
 - Meetup link: https://www.meetup.com/Kubernetes-Turku/events/265794322
+- Recording: https://youtu.be/VoQU2uvHY8w
 - Attendees (according to meetup.com): 23
 - Venue sponsor: [Reaktor](https://www.reaktor.com/)
 - Other sponsor: [luxas labs](https://luxaslabs.com)
@@ -48,6 +49,7 @@ If you're interested in speaking in this meetup, fill out this form: https://bit
 
 - Date: 31 October, 2019 at 17:00 - 20:00
 - Meetup link: https://www.meetup.com/Kubernetes-Turku/events/264987939
+- Recording: https://youtu.be/eyTv2uBL3ag
 - Attendees (according to meetup.com): 49
 - Venue sponsor: [Walkbase](https://www.walkbase.com/)
 - Other sponsor: [luxas labs](https://luxaslabs.com)
@@ -72,4 +74,5 @@ If you're interested in speaking in this meetup, fill out this form: https://bit
   - Slides: https://www.slideshare.net/AntonLindholm2/managing-kubernetes-clusters-easily-with-rancher
 - 19:10 - 19:40: All Meshed Up - How we use Linkerd 
   - Sachin Kundu [@sachinkundu](https://github.com/sachinkundu), [Microsoft](https://www.microsoft.com)
+  - Slides: https://speakerdeck.com/sachinkundu/linkerd2-at-cncf-finland
 - 19:45 - 20:00: Networking 

--- a/turku/meetup.yaml
+++ b/turku/meetup.yaml
@@ -39,7 +39,7 @@ meetups:
       title: Managing Kubernetes clusters easily with Rancher
     - delay: 10m0s
       duration: 30m0s
-      slides: ""
+      slides: https://speakerdeck.com/sachinkundu/linkerd2-at-cncf-finland
       speakers:
       - sachinkundu
       title: All Meshed Up - How we use Linkerd
@@ -48,7 +48,7 @@ meetups:
       slides: ""
       speakers: null
       title: Networking
-    recording: ""
+    recording: https://youtu.be/eyTv2uBL3ag
     sponsors:
     - company: walkbase
       role: Venue
@@ -91,7 +91,7 @@ meetups:
       slides: ""
       speakers: null
       title: Networking
-    recording: ""
+    recording: https://youtu.be/VoQU2uvHY8w
     sponsors:
     - company: reaktor
       role: Venue


### PR DESCRIPTION
This PR adds links to slides and recordings for out meetups, and a placeholder for the next Helsinki one. @netumoliver and Anton Lindholm can fill in with the latest Tampere and Turku data in a later PR. This also fixes a typo earlier where Weaveworks sponsored out meetup instead of DO.